### PR TITLE
Remove whitespace and newline settings from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,3 @@ root = true
 indent_style = space
 
 charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true


### PR DESCRIPTION
Removed settings for trimming trailing whitespace and inserting final newline.