### PR TITLE
Clean up overrides-testReporter.d.ts

### DIFF
--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -7,22 +7,7 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
-import type { TestStatus, Metadata, PlaywrightTestOptions, PlaywrightWorkerOptions, ReporterDescription, FullConfig, FullProject, Location } from './test';
-export type { FullConfig, FullProject, TestStatus, Location } from './test';
-
-/**
- * Result of the full test run.
- */
-export interface FullResult {
-  /**
-   * Status:
    *   - 'passed' - everything went as expected.
    *   - 'failed' - any test has failed.
    *   - 'timedout' - the global time has been reached.


### PR DESCRIPTION
Removed unused imports and comments from the overrides-testReporter type definitions.